### PR TITLE
Fix Zip File Structure Bug for HACS Compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Prepare Files
       run: |
         mkdir bir
-        cp -r custom_components/* bir/
+        cp -r custom_components/bir/* bir/
 
     - name: Zip Files
       run: zip -r bir-${{ github.ref_name }}.zip bir


### PR DESCRIPTION
Addressed an issue where redundant "bir" folders were present in the zip file structure, ensuring that the zip file now only includes the "bir" folder and its contents. This problem likely emerged during the refactoring process to align with the HACS file structure.
