### PR TITLE
docs: updated the docs with instruction on how to install using hacs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 [![Validate with hassfest](https://github.com/SanderBlom/BIR_Waste_Watch/actions/workflows/hassfest.yml/badge.svg)](https://github.com/SanderBlom/BIR_Waste_Watch/actions/workflows/hassfest.yml)
 [![HACS Action](https://github.com/SanderBlom/BIR_Waste_Watch/actions/workflows/hacs.yml/badge.svg)](https://github.com/SanderBlom/BIR_Waste_Watch/actions/workflows/hacs.yml)
 
-:warning: This is not an official integration from BIR!
 ![](/assets/logo.png)
+This is not an official integration from BIR!
 
-This Home Assistant extension dynamically generates sensors for waste collection schedules based on your address. It scrapes the BIR.no website to find the appropriate dates for waste pickup and creates sensors accordingly.
+This Home Assistant extension dynamically generates sensors for waste collection schedules based on your address. It fetches the data from BIRs API to find the appropriate dates for waste pickup and creates sensors accordingly.
 
 ## 🌟 Features
 
-- 📍 Dynamically creates sensors based on the available waste types (e.g., Mixed Waste, Paper & Plastic or Food Waste) for your address.
+- 📍 Dynamically creates sensors based on the available waste types (e.g., Mixed Waste, Paper & Plastic, Food Waste or Glass & Metal) for your address.
 - 🎛 Easy setup through Home Assistant's UI.
 
 ## 📝 Prerequisites
@@ -20,6 +20,20 @@ This Home Assistant extension dynamically generates sensors for waste collection
 - Your garbage is picked up by BIR and your address is listed in BIR.no's database.
 
 ## 📦 Installation
+
+### Option 1: HACS
+- Follow [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=sanderblom&repository=690180198&category=integration) and install it
+- Restart Home Assistant
+
+  *or*
+- Go to `HACS` -> `Integrations`,
+- Select `+`,
+- Search for `BIR Waste Watch` and install it,
+- Restart Home Assistant
+- Go to `Devices & services` and click add integration and search for `BIR Waste Watch`
+- Follow the configuration guide bellow
+
+### Option 2: Manual
 
 1. **Download the latest release [here](https://github.com/SanderBlom/BIR_Waste_Watch/releases).**
 
@@ -41,12 +55,12 @@ This Home Assistant extension dynamically generates sensors for waste collection
     - Click **Add Integration**.
     - Search for **BIR Waste Watch** and click to add.
 
-5. **Configuration**
+## Configuration 
 
 During the setup phase, you'll need to provide a URL from BIR.no
 
 1. Go to [bir.no](https://bir.no/).
-2. Enter your address in the search field.
+2. Enter your address in the search field and click on your address.
 3. Once you can see the dates, copy the URL from the address bar(should looks something similar to this: `https://bir.no/adressesoek/?rId=c2435f0f-2e4b-4908-86cf-bafbd3a2cf61&name=Lillehatten%20330,%20Bergen`).
 4. Paste this URL into the setup phase of the integration in Home Assistant's UI.
 


### PR DESCRIPTION
- Added new installation instructions using hacs 
- Updated the documentation to clarify that the BIR API is now used, replacing the web scraping approach from version 1.x.x.