### PR TITLE
fix: remove duplicate return statement in __init__.py

### DIFF
--- a/custom_components/bir/__init__.py
+++ b/custom_components/bir/__init__.py
@@ -68,8 +68,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     return True
 
-    return True
-
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload BIR Waste Watch config entry."""


### PR DESCRIPTION
## Summary
Removes unreachable duplicate \`return True\` statement in \`__init__.py\`.

## Changes
- Removed dead code (duplicate return statement) at line 67

## Type
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] All tests pass