### PR TITLE
fix: add 30-second timeout to API requests

### DIFF
--- a/custom_components/bir/const.py
+++ b/custom_components/bir/const.py
@@ -18,6 +18,9 @@ API_PROVIDER_ID: Final = "100;300;400"
 # Update interval
 SCAN_INTERVAL: Final = timedelta(hours=1)
 
+# API request timeout (seconds)
+API_TIMEOUT: Final = 30
+
 # Waste type mappings (Norwegian to English)
 WASTE_TYPE_MAP: Final = {
     "Restavfall": "Mixed Waste",

--- a/custom_components/bir/coordinator.py
+++ b/custom_components/bir/coordinator.py
@@ -8,7 +8,7 @@ import re
 from typing import Any
 from urllib.parse import unquote
 
-from aiohttp import ClientResponseError, ClientSession
+from aiohttp import ClientResponseError, ClientSession, ClientTimeout
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -18,6 +18,7 @@ from .const import (
     API_LOGIN_URL,
     API_PICKUP_URL,
     API_PROVIDER_ID,
+    API_TIMEOUT,
     DOMAIN,
     SCAN_INTERVAL,
     WASTE_TYPE_MAP,
@@ -139,7 +140,10 @@ class BIRDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "oppdragsgiverId": API_PROVIDER_ID,
         }
 
-        async with self.session.post(API_LOGIN_URL, json=payload) as response:
+        timeout = ClientTimeout(total=API_TIMEOUT)
+        async with self.session.post(
+            API_LOGIN_URL, json=payload, timeout=timeout
+        ) as response:
             response.raise_for_status()
             token = response.headers.get("Token")
             if not token:
@@ -169,8 +173,9 @@ class BIRDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         }
         headers = {"Token": self._token}
 
+        timeout = ClientTimeout(total=API_TIMEOUT)
         async with self.session.get(
-            API_PICKUP_URL, headers=headers, params=params
+            API_PICKUP_URL, headers=headers, params=params, timeout=timeout
         ) as response:
             response.raise_for_status()
             pickup_data = await response.json()


### PR DESCRIPTION
## Summary
Adds explicit timeout to all API requests to prevent hanging connections from blocking the event loop.

## Changes
- Add \`API_TIMEOUT\` constant (30 seconds) to \`const.py\`
- Apply \`ClientTimeout\` to login and fetch requests in \`coordinator.py\`

## Why
Without explicit timeouts, a hanging API server could cause the integration to block indefinitely.

## Type
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] All tests pass