### PR TITLE
fix: extract magic numbers to constants

### DIFF
--- a/custom_components/bir/const.py
+++ b/custom_components/bir/const.py
@@ -21,6 +21,9 @@ SCAN_INTERVAL: Final = timedelta(hours=1)
 # API request timeout (seconds)
 API_TIMEOUT: Final = 30
 
+# Number of days to look ahead for pickup dates
+PICKUP_LOOKUP_DAYS: Final = 95
+
 # Waste type mappings (Norwegian to English)
 WASTE_TYPE_MAP: Final = {
     "Restavfall": "Mixed Waste",

--- a/custom_components/bir/coordinator.py
+++ b/custom_components/bir/coordinator.py
@@ -21,6 +21,7 @@ from .const import (
     API_PROVIDER_ID,
     API_TIMEOUT,
     DOMAIN,
+    PICKUP_LOOKUP_DAYS,
     SCAN_INTERVAL,
     WASTE_TYPE_MAP,
 )
@@ -170,7 +171,7 @@ class BIRDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         params = {
             "eiendomId": self.property_id,
             "datoFra": now.strftime("%Y-%m-%d"),
-            "datoTil": (now + timedelta(days=95)).strftime("%Y-%m-%d"),
+            "datoTil": (now + timedelta(days=PICKUP_LOOKUP_DAYS)).strftime("%Y-%m-%d"),
         }
         headers = {"Token": self._token}
 


### PR DESCRIPTION
- Add PICKUP_LOOKUP_DAYS constant (95 days)
- Replace hard-coded value in coordinator with constant
- Improves maintainability and makes config more explicit