### PR TITLE
fix: remove unused constants from const.py

### DIFF
--- a/custom_components/bir/const.py
+++ b/custom_components/bir/const.py
@@ -26,16 +26,5 @@ WASTE_TYPE_MAP: Final = {
     "Glass og metallemballasje": "Glass And Metal Packaging",
 }
 
-# Sensor types
-SENSOR_TYPE_DATE: Final = "date"
-SENSOR_TYPE_DAYS: Final = "days"
-
-# Attributes
-ATTR_LAST_UPDATED: Final = "last_updated"
-ATTR_WASTE_TYPE: Final = "waste_type"
-ATTR_PICKUP_DATE: Final = "pickup_date"
-
 # Config keys
 CONF_URL: Final = "url"
-CONF_PROPERTY_ID: Final = "property_id"
-CONF_ADDRESS: Final = "address"


### PR DESCRIPTION
- Remove SENSOR_TYPE_DATE, SENSOR_TYPE_DAYS
- Remove ATTR_LAST_UPDATED, ATTR_WASTE_TYPE, ATTR_PICKUP_DATE
- Remove CONF_PROPERTY_ID, CONF_ADDRESS
- Keeps codebase clean and reduces confusion