### PR TITLE
feat: add address search to config flow

### DIFF
--- a/custom_components/__init__.py
+++ b/custom_components/__init__.py
@@ -1,0 +1,1 @@
+"""Custom components for Home Assistant."""

--- a/custom_components/bir/__init__.py
+++ b/custom_components/bir/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import CONF_URL, DOMAIN
+from .const import CONF_ADDRESS, CONF_PROPERTY_ID, CONF_URL, DOMAIN
 from .coordinator import (
     BIRDataUpdateCoordinator,
     BIRTokenStorage,
@@ -32,13 +32,20 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up BIR Waste Watch from a config entry."""
-    url = entry.data[CONF_URL]
-    property_id = extract_property_id(url)
-    address = extract_address(url) or "Unknown"
+    # Support both new (property_id) and legacy (url) config formats
+    if CONF_PROPERTY_ID in entry.data:
+        # New format: direct property_id and address
+        property_id = entry.data[CONF_PROPERTY_ID]
+        address = entry.data.get(CONF_ADDRESS, "Unknown")
+    else:
+        # Legacy format: extract from URL
+        url = entry.data[CONF_URL]
+        property_id = extract_property_id(url)
+        address = extract_address(url) or "Unknown"
 
-    if not property_id:
-        _LOGGER.error("Could not extract property ID from URL")
-        return False
+        if not property_id:
+            _LOGGER.error("Could not extract property ID from URL")
+            return False
 
     session = async_get_clientsession(hass)
 

--- a/custom_components/bir/config_flow.py
+++ b/custom_components/bir/config_flow.py
@@ -4,50 +4,29 @@ from __future__ import annotations
 
 import logging
 from typing import Any
-from urllib.parse import parse_qs, urlparse
 
 from homeassistant import config_entries
-from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResult
+from homeassistant.core import callback
+from homeassistant.data_entry_flow import AbortFlow, FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.selector import (
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
 import voluptuous as vol
 
-from .const import CONF_URL, DOMAIN
-from .coordinator import BIRDataUpdateCoordinator, extract_address, extract_property_id
+from .const import CONF_ADDRESS, CONF_PROPERTY_ID, DOMAIN
+from .coordinator import BIRDataUpdateCoordinator, async_search_addresses
 
 _LOGGER = logging.getLogger(__name__)
 
-STEP_USER_DATA_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_URL, default=""): str,
-    }
-)
-
-
-async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, str]:
-    """Validate the user input allows us to connect."""
-    url = data[CONF_URL]
-    property_id = extract_property_id(url)
-    address = extract_address(url)
-
-    if not property_id:
-        raise InvalidPropertyId
-
-    session = async_get_clientsession(hass)
-    coordinator = BIRDataUpdateCoordinator(
-        hass,
-        session,
-        property_id,
-        address or "Unknown",
-    )
-
-    # Test the connection
-    await coordinator.async_test_connection()
-
-    return {
-        "title": address or f"Property {property_id}",
-        "property_id": property_id,
-    }
+# Minimum characters before searching
+MIN_SEARCH_LENGTH = 3
 
 
 class BIRConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -55,50 +34,163 @@ class BIRConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._addresses: list[dict[str, Any]] = []
+        self._search_query: str = ""
+
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Handle the initial step."""
+        """Handle the initial step - address search."""
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            url = user_input.get(CONF_URL, "")
-            parsed_url = urlparse(url)
+            search_query = user_input.get("address_search", "").strip()
 
-            # Check if the URL is from bir.no
-            if parsed_url.netloc != "bir.no":
-                errors["base"] = "invalid_url_domain"
+            if len(search_query) < MIN_SEARCH_LENGTH:
+                errors["base"] = "search_too_short"
             else:
-                # Check if the URL contains rId and name parameters
-                query_params = parse_qs(parsed_url.query)
-                if "rId" not in query_params or "name" not in query_params:
-                    errors["base"] = "missing_parameters"
-
-            if not errors:
                 try:
-                    info = await validate_input(self.hass, user_input)
-                except InvalidPropertyId:
-                    errors["base"] = "missing_parameters"
-                except Exception:
-                    _LOGGER.exception("Unexpected exception")
-                    errors["base"] = "cannot_connect"
-                else:
-                    # Set unique ID to prevent duplicate entries
-                    property_id = extract_property_id(url)
-                    await self.async_set_unique_id(f"bir_{property_id}")
-                    self._abort_if_unique_id_configured()
-
-                    return self.async_create_entry(
-                        title=info["title"],
-                        data={CONF_URL: url},
+                    session = async_get_clientsession(self.hass)
+                    self._addresses = await async_search_addresses(
+                        session, search_query
                     )
+                    self._search_query = search_query
+
+                    if not self._addresses:
+                        errors["base"] = "no_addresses_found"
+                    else:
+                        # Move to address selection step
+                        return await self.async_step_select_address()
+
+                except Exception:
+                    _LOGGER.exception("Error searching for addresses")
+                    errors["base"] = "cannot_connect"
 
         return self.async_show_form(
             step_id="user",
-            data_schema=STEP_USER_DATA_SCHEMA,
+            data_schema=vol.Schema(
+                {
+                    vol.Required("address_search", default=""): TextSelector(
+                        TextSelectorConfig(
+                            type=TextSelectorType.TEXT,
+                            autocomplete="street-address",
+                        )
+                    ),
+                }
+            ),
             errors=errors,
+            description_placeholders={"min_chars": str(MIN_SEARCH_LENGTH)},
         )
 
+    async def async_step_select_address(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle address selection step."""
+        errors: dict[str, str] = {}
 
-class InvalidPropertyId(Exception):
-    """Error to indicate invalid property ID."""
+        if user_input is not None:
+            selected_id = user_input.get("selected_address")
+
+            if selected_id == "__search_again__":
+                # Go back to search
+                return await self.async_step_user()
+
+            if selected_id:
+                # Find the selected address
+                selected = next(
+                    (a for a in self._addresses if a["id"] == selected_id), None
+                )
+                if selected:
+                    # Validate the property works
+                    try:
+                        session = async_get_clientsession(self.hass)
+                        coordinator = BIRDataUpdateCoordinator(
+                            self.hass,
+                            session,
+                            selected["id"],
+                            selected["adresse"],
+                        )
+                        await coordinator.async_test_connection()
+
+                        # Set unique ID to prevent duplicates
+                        await self.async_set_unique_id(f"bir_{selected['id']}")
+                        self._abort_if_unique_id_configured()
+
+                        return self.async_create_entry(
+                            title=selected["adresse"],
+                            data={
+                                CONF_PROPERTY_ID: selected["id"],
+                                CONF_ADDRESS: selected["adresse"],
+                            },
+                        )
+                    except AbortFlow:
+                        raise
+                    except Exception:
+                        _LOGGER.exception("Error validating property")
+                        errors["base"] = "cannot_connect"
+
+        # Build address options
+        options = [
+            SelectOptionDict(
+                value=addr["id"],
+                label=f"{addr['adresse']} ({addr.get('kommune', '')})",
+            )
+            for addr in self._addresses
+        ]
+
+        # Add search again option at the end
+        options.append(
+            SelectOptionDict(
+                value="__search_again__",
+                label="🔍 Search again...",
+            )
+        )
+
+        return self.async_show_form(
+            step_id="select_address",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("selected_address"): SelectSelector(
+                        SelectSelectorConfig(
+                            options=options,
+                            mode=SelectSelectorMode.LIST,
+                        )
+                    ),
+                }
+            ),
+            errors=errors,
+            description_placeholders={
+                "count": str(len(self._addresses)),
+                "query": self._search_query,
+            },
+        )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> config_entries.OptionsFlow:
+        """Create the options flow."""
+        return BIROptionsFlowHandler(config_entry)
+
+
+class BIROptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle options flow for BIR Waste Watch."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema({}),
+        )

--- a/custom_components/bir/const.py
+++ b/custom_components/bir/const.py
@@ -10,6 +10,7 @@ MANUFACTURER: Final = "BIR"
 API_BASE_URL: Final = "https://webservice.bir.no/api"
 API_LOGIN_URL: Final = f"{API_BASE_URL}/login"
 API_PICKUP_URL: Final = f"{API_BASE_URL}/tomminger"
+API_ADDRESS_SEARCH_URL: Final = f"{API_BASE_URL}/eiendommer"
 
 # API credentials
 API_APP_ID: Final = "94FA72AD-583D-4AA3-988F-491F694DFB7B"
@@ -34,3 +35,5 @@ WASTE_TYPE_MAP: Final = {
 
 # Config keys
 CONF_URL: Final = "url"
+CONF_PROPERTY_ID: Final = "property_id"
+CONF_ADDRESS: Final = "address"

--- a/custom_components/bir/coordinator.py
+++ b/custom_components/bir/coordinator.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
+    API_ADDRESS_SEARCH_URL,
     API_APP_ID,
     API_LOGIN_URL,
     API_PICKUP_URL,
@@ -244,3 +245,44 @@ def extract_address(url: str) -> str | None:
     if match:
         return unquote(match.group(1))
     return None
+
+
+async def async_search_addresses(
+    session: ClientSession, query: str, token: str | None = None
+) -> list[dict[str, Any]]:
+    """Search for addresses using the BIR API.
+
+    Args:
+        session: aiohttp client session.
+        query: Address search query (street name, partial address, etc.).
+        token: Optional auth token. If not provided, will login first.
+
+    Returns:
+        List of matching properties with id, address, municipality, etc.
+
+    """
+    # Get token if not provided
+    if not token:
+        payload = {
+            "applikasjonsId": API_APP_ID,
+            "oppdragsgiverId": API_PROVIDER_ID,
+        }
+        timeout = ClientTimeout(total=API_TIMEOUT)
+        async with session.post(
+            API_LOGIN_URL, json=payload, timeout=timeout
+        ) as response:
+            response.raise_for_status()
+            token = response.headers.get("Token")
+            if not token:
+                raise ValueError("Login failed: Token not found")
+
+    # Search for addresses
+    params = {"adresse": query}
+    headers = {"Token": token}
+    timeout = ClientTimeout(total=API_TIMEOUT)
+
+    async with session.get(
+        API_ADDRESS_SEARCH_URL, headers=headers, params=params, timeout=timeout
+    ) as response:
+        response.raise_for_status()
+        return await response.json()

--- a/custom_components/bir/strings.json
+++ b/custom_components/bir/strings.json
@@ -3,16 +3,25 @@
     "step": {
       "user": {
         "title": "BIR Waste Watch",
-        "description": "Enter your personal BIR calendar URL. You can find this on the BIR website.",
+        "description": "Search for your address to set up waste collection tracking. Enter at least {min_chars} characters.",
         "data": {
-          "url": "Personal bir.no URL"
+          "address_search": "Street address"
+        }
+      },
+      "select_address": {
+        "title": "Select Your Address",
+        "description": "Found {count} addresses matching \"{query}\". Select your address from the list below.",
+        "data": {
+          "selected_address": "Address"
         }
       }
     },
     "error": {
+      "search_too_short": "Please enter at least 3 characters to search",
+      "no_addresses_found": "No addresses found. Try a different search term.",
+      "cannot_connect": "Failed to connect to BIR API",
       "invalid_url_domain": "Invalid URL - must be from bir.no",
-      "missing_parameters": "Missing required parameters in URL (rId and name)",
-      "cannot_connect": "Failed to connect to BIR API"
+      "missing_parameters": "Missing required parameters in URL (rId and name)"
     },
     "abort": {
       "already_configured": "This address is already configured"
@@ -23,7 +32,7 @@
       "collection_date": {
         "name": "{waste_type} Collection Date"
       },
-      "days_until": {
+      "days_until_pickup": {
         "name": "{waste_type} Days Until Pickup"
       }
     }

--- a/custom_components/bir/translations/en.json
+++ b/custom_components/bir/translations/en.json
@@ -3,16 +3,25 @@
     "step": {
       "user": {
         "title": "BIR Waste Watch",
-        "description": "Enter your personal BIR calendar URL. You can find this on the BIR website.",
+        "description": "Search for your address to set up waste collection tracking. Enter at least {min_chars} characters.",
         "data": {
-          "url": "Personal bir.no URL"
+          "address_search": "Street address"
+        }
+      },
+      "select_address": {
+        "title": "Select Your Address",
+        "description": "Found {count} addresses matching \"{query}\". Select your address from the list below.",
+        "data": {
+          "selected_address": "Address"
         }
       }
     },
     "error": {
+      "search_too_short": "Please enter at least 3 characters to search",
+      "no_addresses_found": "No addresses found. Try a different search term.",
+      "cannot_connect": "Failed to connect to BIR API",
       "invalid_url_domain": "Invalid URL - must be from bir.no",
-      "missing_parameters": "Missing required parameters in URL (rId and name)",
-      "cannot_connect": "Failed to connect to BIR API"
+      "missing_parameters": "Missing required parameters in URL (rId and name)"
     },
     "abort": {
       "already_configured": "This address is already configured"

--- a/custom_components/bir/translations/nb.json
+++ b/custom_components/bir/translations/nb.json
@@ -3,16 +3,25 @@
     "step": {
       "user": {
         "title": "BIR Avfallsvakt",
-        "description": "Skriv inn din personlige BIR kalender-URL. Du finner denne på BIR sine nettsider.",
+        "description": "Søk etter din adresse for å sette opp avfallshentevarsel. Skriv inn minst {min_chars} tegn.",
         "data": {
-          "url": "Personlig bir.no URL"
+          "address_search": "Gateadresse"
+        }
+      },
+      "select_address": {
+        "title": "Velg din adresse",
+        "description": "Fant {count} adresser som matcher \"{query}\". Velg din adresse fra listen.",
+        "data": {
+          "selected_address": "Adresse"
         }
       }
     },
     "error": {
+      "search_too_short": "Skriv inn minst 3 tegn for å søke",
+      "no_addresses_found": "Ingen adresser funnet. Prøv et annet søkeord.",
+      "cannot_connect": "Kunne ikke koble til BIR API",
       "invalid_url_domain": "Ugyldig URL - må være fra bir.no",
-      "missing_parameters": "Manglende parametre i URL (rId og name)",
-      "cannot_connect": "Kunne ikke koble til BIR API"
+      "missing_parameters": "Manglende parametre i URL (rId og name)"
     },
     "abort": {
       "already_configured": "Denne adressen er allerede konfigurert"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,15 @@
 services:
   homeassistant:
     restart: unless-stopped
-    image: ghcr.io/home-assistant/home-assistant:stable
+    image: homeassistant/home-assistant:stable
     container_name: homeassistant_dev
-    network_mode: host
-    privileged: true
+    ports:
+      - "8123:8123"
     volumes:
-      - ./custom_components/bir/:/config/custom_components/BIR_Waste_Watch
-      - ./src/translations:/config/custom_components/BIR_Waste_Watch/translations
-      - /etc/homeassistant/config:/config
+      - ./custom_components/bir:/config/custom_components/bir
+      - ha_config:/config
     environment:
       - TZ=Europe/Oslo
+
+volumes:
+  ha_config:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ include = ["custom_components*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["."]
 norecursedirs = [".git", "testing_config"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -5,155 +5,253 @@ from unittest.mock import AsyncMock, patch
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-DOMAIN = "bir"
+from custom_components.bir.config_flow import BIRConfigFlow
+from custom_components.bir.const import DOMAIN
+
+# Sample address search results from BIR API
+MOCK_ADDRESSES = [
+    {"id": "12345", "adresse": "Testveien 1", "kommune": "Bergen"},
+    {"id": "12346", "adresse": "Testveien 2", "kommune": "Bergen"},
+    {"id": "12347", "adresse": "Testveien 3", "kommune": "Bergen"},
+]
 
 
-async def test_form(hass: HomeAssistant) -> None:
-    """Test we get the form."""
+@pytest.fixture(autouse=True)
+def register_config_flow(hass: HomeAssistant) -> None:
+    """Register the config flow handler."""
+    config_entries.HANDLERS.register(DOMAIN)(BIRConfigFlow)
+
+
+async def test_form_shows_search(hass: HomeAssistant) -> None:
+    """Test we get the address search form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
     assert result["errors"] == {}
 
 
-async def test_form_valid_url(hass: HomeAssistant, mock_setup_entry) -> None:
-    """Test we can configure with a valid URL."""
+async def test_search_too_short(hass: HomeAssistant) -> None:
+    """Test error when search query is too short."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"address_search": "ab"},
+    )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["step_id"] == "user"
+    assert result2["errors"] == {"base": "search_too_short"}
+
+
+async def test_search_no_results(hass: HomeAssistant) -> None:
+    """Test error when no addresses are found."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
     with patch(
-        "custom_components.bir.config_flow.BIRDataUpdateCoordinator.async_test_connection",
+        "custom_components.bir.config_flow.async_search_addresses",
         new_callable=AsyncMock,
+        return_value=[],
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {
-                "url": "https://bir.no/tjenester/tommekalender/?rId=12345&name=TestAddress",
-            },
+            {"address_search": "Nonexistent street"},
         )
-        await hass.async_block_till_done()
-
-    assert result2["type"] == FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "TestAddress"
-    assert result2["data"] == {
-        "url": "https://bir.no/tjenester/tommekalender/?rId=12345&name=TestAddress"
-    }
-    assert len(mock_setup_entry.mock_calls) == 1
-
-
-async def test_form_invalid_domain(hass: HomeAssistant) -> None:
-    """Test we handle invalid domain."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    # Note: config_flow validates domain before checking parameters,
-    # so we need a URL with valid params but wrong domain
-    result2 = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {
-            "url": "https://example.com/page?rId=123&name=Test",
-        },
-    )
 
     assert result2["type"] == FlowResultType.FORM
-    assert result2["errors"] == {"base": "invalid_url_domain"}
+    assert result2["step_id"] == "user"
+    assert result2["errors"] == {"base": "no_addresses_found"}
 
 
-async def test_form_missing_parameters(hass: HomeAssistant) -> None:
-    """Test we handle missing URL parameters."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    result2 = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {
-            "url": "https://bir.no/tjenester/tommekalender/",
-        },
-    )
-
-    assert result2["type"] == FlowResultType.FORM
-    assert result2["errors"] == {"base": "missing_parameters"}
-
-
-async def test_form_missing_rid(hass: HomeAssistant) -> None:
-    """Test we handle missing rId parameter."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    result2 = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {
-            "url": "https://bir.no/tjenester/tommekalender/?name=TestAddress",
-        },
-    )
-
-    assert result2["type"] == FlowResultType.FORM
-    assert result2["errors"] == {"base": "missing_parameters"}
-
-
-async def test_form_missing_name(hass: HomeAssistant) -> None:
-    """Test we handle missing name parameter."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    result2 = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {
-            "url": "https://bir.no/tjenester/tommekalender/?rId=12345",
-        },
-    )
-
-    assert result2["type"] == FlowResultType.FORM
-    assert result2["errors"] == {"base": "missing_parameters"}
-
-
-async def test_form_cannot_connect(hass: HomeAssistant) -> None:
-    """Test we handle connection errors."""
+async def test_search_connection_error(hass: HomeAssistant) -> None:
+    """Test error when API connection fails during search."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
     with patch(
-        "custom_components.bir.config_flow.BIRDataUpdateCoordinator.async_test_connection",
+        "custom_components.bir.config_flow.async_search_addresses",
         new_callable=AsyncMock,
         side_effect=Exception("Connection failed"),
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {
-                "url": "https://bir.no/tjenester/tommekalender/?rId=12345&name=TestAddress",
-            },
+            {"address_search": "Testveien"},
         )
 
     assert result2["type"] == FlowResultType.FORM
+    assert result2["step_id"] == "user"
     assert result2["errors"] == {"base": "cannot_connect"}
 
 
-async def test_form_already_configured(hass: HomeAssistant, mock_config_entry) -> None:
-    """Test we handle already configured entry."""
-    mock_config_entry.add_to_hass(hass)
-
+async def test_search_shows_select_step(hass: HomeAssistant) -> None:
+    """Test successful search shows address selection step."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
     with patch(
-        "custom_components.bir.config_flow.BIRDataUpdateCoordinator.async_test_connection",
+        "custom_components.bir.config_flow.async_search_addresses",
         new_callable=AsyncMock,
+        return_value=MOCK_ADDRESSES,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {
-                "url": "https://bir.no/tjenester/tommekalender/?rId=12345&name=TestAddress",
-            },
+            {"address_search": "Testveien"},
         )
 
-    assert result2["type"] == FlowResultType.ABORT
-    assert result2["reason"] == "already_configured"
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["step_id"] == "select_address"
+
+
+async def test_select_address_creates_entry(
+    hass: HomeAssistant, mock_setup_entry
+) -> None:
+    """Test selecting an address creates a config entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    # Step 1: Search for addresses
+    with patch(
+        "custom_components.bir.config_flow.async_search_addresses",
+        new_callable=AsyncMock,
+        return_value=MOCK_ADDRESSES,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"address_search": "Testveien"},
+        )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["step_id"] == "select_address"
+
+    # Step 2: Select an address
+    with patch(
+        "custom_components.bir.config_flow.BIRDataUpdateCoordinator.async_test_connection",
+        new_callable=AsyncMock,
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"selected_address": "12345"},
+        )
+        await hass.async_block_till_done()
+
+    assert result3["type"] == FlowResultType.CREATE_ENTRY
+    assert result3["title"] == "Testveien 1"
+    assert result3["data"] == {
+        "property_id": "12345",
+        "address": "Testveien 1",
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_select_address_validation_error(hass: HomeAssistant) -> None:
+    """Test error when address validation fails."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    # Step 1: Search for addresses
+    with patch(
+        "custom_components.bir.config_flow.async_search_addresses",
+        new_callable=AsyncMock,
+        return_value=MOCK_ADDRESSES,
+    ):
+        await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"address_search": "Testveien"},
+        )
+
+    # Step 2: Select an address (fails validation)
+    with patch(
+        "custom_components.bir.config_flow.BIRDataUpdateCoordinator.async_test_connection",
+        new_callable=AsyncMock,
+        side_effect=Exception("Validation failed"),
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"selected_address": "12345"},
+        )
+
+    assert result3["type"] == FlowResultType.FORM
+    assert result3["step_id"] == "select_address"
+    assert result3["errors"] == {"base": "cannot_connect"}
+
+
+async def test_search_again_option(hass: HomeAssistant) -> None:
+    """Test selecting 'search again' returns to search step."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    # Step 1: Search for addresses
+    with patch(
+        "custom_components.bir.config_flow.async_search_addresses",
+        new_callable=AsyncMock,
+        return_value=MOCK_ADDRESSES,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"address_search": "Testveien"},
+        )
+
+    assert result2["step_id"] == "select_address"
+
+    # Step 2: Select "search again"
+    result3 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"selected_address": "__search_again__"},
+    )
+
+    assert result3["type"] == FlowResultType.FORM
+    assert result3["step_id"] == "user"
+
+
+async def test_already_configured(hass: HomeAssistant) -> None:
+    """Test we abort if address is already configured."""
+    # Create an existing entry with the same unique_id
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Testveien 1",
+        data={"property_id": "12345", "address": "Testveien 1"},
+        unique_id="bir_12345",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    # Step 1: Search for addresses
+    with patch(
+        "custom_components.bir.config_flow.async_search_addresses",
+        new_callable=AsyncMock,
+        return_value=MOCK_ADDRESSES,
+    ):
+        await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"address_search": "Testveien"},
+        )
+
+    # Step 2: Select the already configured address
+    with patch(
+        "custom_components.bir.config_flow.BIRDataUpdateCoordinator.async_test_connection",
+        new_callable=AsyncMock,
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"selected_address": "12345"},
+        )
+
+    assert result3["type"] == FlowResultType.ABORT
+    assert result3["reason"] == "already_configured"


### PR DESCRIPTION
- Replace URL-based configuration with address search
- Add async_search_addresses function to coordinator
- Multi-step config flow: search -> select address
- Add new constants: API_ADDRESS_SEARCH_URL, CONF_PROPERTY_ID, CONF_ADDRESS
- Support backward compatibility with legacy URL-based config
- Re-raise AbortFlow in exception handling to properly handle duplicates
- Add custom_components/__init__.py for test discovery
- Update tests for new config flow
- Update translations (en, nb)