### PR TITLE
fix: show user-friendly message for API timeout errors

### DIFF
--- a/custom_components/bir/coordinator.py
+++ b/custom_components/bir/coordinator.py
@@ -144,6 +144,11 @@ class BIRDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 raise
 
         except ClientResponseError as err:
+            if err.status == 504:
+                raise UpdateFailed(
+                    "BIR API is not responding (timeout). This is likely a temporary "
+                    "issue with BIR's servers. Will retry automatically."
+                ) from err
             raise UpdateFailed(f"Error communicating with BIR API: {err}") from err
         except Exception as err:
             raise UpdateFailed(f"Unexpected error: {err}") from err


### PR DESCRIPTION
- This should display a better a message to users when the API timeout. It should now show something like `Failed setup, will retry: BIR API is not responding (timeout). This is likely a temporary issue with BIR's servers. Will retry automatically.` instead of `Failed setup, will retry: Error communicating with BIR API: 504, message='Gateway Time-out', url='https://webservice.bir.no/api/tomminger?eiendomId=your-id&datoFra=2026-01-14&datoTil=2026-04-19`