### PR TITLE
fix: missing addresses from search

### DIFF
--- a/custom_components/bir/config_flow.py
+++ b/custom_components/bir/config_flow.py
@@ -135,7 +135,7 @@ class BIRConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         options = [
             SelectOptionDict(
                 value=addr["id"],
-                label=f"{addr['adresse']} ({addr.get('kommune', '')})",
+                label=addr["adresse"],
             )
             for addr in self._addresses
         ]
@@ -278,7 +278,7 @@ class BIROptionsFlowHandler(config_entries.OptionsFlow):
         options = [
             SelectOptionDict(
                 value=addr["id"],
-                label=f"{addr['adresse']} ({addr.get('kommune', '')})",
+                label=addr["adresse"],
             )
             for addr in self._addresses
         ]

--- a/custom_components/bir/const.py
+++ b/custom_components/bir/const.py
@@ -10,7 +10,9 @@ MANUFACTURER: Final = "BIR"
 API_BASE_URL: Final = "https://webservice.bir.no/api"
 API_LOGIN_URL: Final = f"{API_BASE_URL}/login"
 API_PICKUP_URL: Final = f"{API_BASE_URL}/tomminger"
-API_ADDRESS_SEARCH_URL: Final = f"{API_BASE_URL}/eiendommer"
+# Address search uses the BIR website API which has a more complete database
+# than the webservice API (includes Askøy and other municipalities)
+API_ADDRESS_SEARCH_URL: Final = "https://bir.no/api/search/AddressSearch"
 
 # API credentials
 API_APP_ID: Final = "94FA72AD-583D-4AA3-988F-491F694DFB7B"

--- a/custom_components/bir/coordinator.py
+++ b/custom_components/bir/coordinator.py
@@ -6,7 +6,7 @@ import datetime as dt
 from datetime import datetime, timedelta
 import logging
 import re
-from typing import Any
+from typing import Any, TypedDict
 from urllib.parse import unquote
 
 from aiohttp import ClientResponseError, ClientSession, ClientTimeout
@@ -283,42 +283,40 @@ def extract_address(url: str) -> str | None:
     return None
 
 
+class AddressSearchResult(TypedDict):
+    """Type definition for address search results."""
+
+    id: str
+    adresse: str
+
+
 async def async_search_addresses(
-    session: ClientSession, query: str, token: str | None = None
-) -> list[dict[str, Any]]:
-    """Search for addresses using the BIR API.
+    session: ClientSession, query: str | None = None
+) -> list[AddressSearchResult]:
+    """Search for addresses using the BIR website API.
 
     Args:
         session: aiohttp client session.
         query: Address search query (street name, partial address, etc.).
-        token: Optional auth token. If not provided, will login first.
 
     Returns:
-        List of matching properties with id, address, municipality, etc.
+        List of matching properties with id and address.
 
     """
-    # Get token if not provided
-    if not token:
-        payload = {
-            "applikasjonsId": API_APP_ID,
-            "oppdragsgiverId": API_PROVIDER_ID,
-        }
-        timeout = ClientTimeout(total=API_TIMEOUT)
-        async with session.post(
-            API_LOGIN_URL, json=payload, timeout=timeout
-        ) as response:
-            response.raise_for_status()
-            token = response.headers.get("Token")
-            if not token:
-                raise ValueError("Login failed: Token not found")
-
-    # Search for addresses
-    params = {"adresse": query}
-    headers = {"Token": token}
+    params = {"q": query, "s": "false"}
     timeout = ClientTimeout(total=API_TIMEOUT)
 
     async with session.get(
-        API_ADDRESS_SEARCH_URL, headers=headers, params=params, timeout=timeout
+        API_ADDRESS_SEARCH_URL, params=params, timeout=timeout
     ) as response:
         response.raise_for_status()
-        return await response.json()
+        results = await response.json()
+
+    return [
+        {
+            "id": item.get("Id"),
+            "adresse": f"{item.get('Title', '')}, {item.get('SubTitle', '')}",
+        }
+        for item in results
+        if item.get("Id")
+    ]

--- a/custom_components/bir/manifest.json
+++ b/custom_components/bir/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/SanderBlom/BIR_Waste_Watch/issues",
   "requirements": [],
-  "version": "2.2.1"
+  "version": "2.2.2"
 }


### PR DESCRIPTION
## Problem
Users in certain municipalities (e.g., Askøy) could not find their addresses when setting up the integration, even though the same addresses work correctly on bir.no.

## Root cause
The integration was using the address search endpoint at webservice.bir.no/api/eiendommer, which has an incomplete database — missing addresses from Askøy and potentially other regions.

## Solution
Switched to the address search API used by the BIR website (bir.no/api/search/AddressSearch), which returns the complete set of addresses matching what users see on bir.no.

Note: The pickup schedule endpoint (webservice.bir.no/api/tomminger) remains unchanged, as the property IDs are compatible between both APIs.

